### PR TITLE
`flag` module function and type name cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+- rename flag `*_list` functions
+- rename `flag.FlagValue` to `flag.Value`
+- rename `flag.FlagMap` to `flag.Map`
+
 ## [0.6.0] - 2022-02-11
 
 - `Runner` returns a generic type

--- a/src/glint.gleam
+++ b/src/glint.gleam
@@ -8,7 +8,7 @@ import gleam/string
 import gleam/bool
 import gleam/function
 import snag.{Result}
-import glint/flag.{Flag, FlagMap}
+import glint/flag.{Flag, Map as FlagMap}
 
 /// Input type for `Runner`.
 ///

--- a/src/glint/flag.gleam
+++ b/src/glint/flag.gleam
@@ -1,6 +1,6 @@
 import gleam
 import gleam/bool
-import gleam/map.{Map}
+import gleam/map
 import gleam/string
 import gleam/result
 import gleam/int
@@ -82,11 +82,11 @@ pub fn bool(called name: String, default value: Bool) -> Flag {
 }
 
 /// Associate flag names to their current values.
-pub type FlagMap =
-  Map(String, Value)
+pub type Map =
+  map.Map(String, Value)
 
-/// Convert a list of flags to a FlagMap.
-pub fn build_map(flags: List(Flag)) -> FlagMap {
+/// Convert a list of flags to a Map.
+pub fn build_map(flags: List(Flag)) -> Map {
   list.fold(
     flags,
     map.new(),
@@ -97,10 +97,7 @@ pub fn build_map(flags: List(Flag)) -> FlagMap {
 /// Updates a flag balue, ensuring that the new value can satisfy the required type.
 /// Assumes that all flag inputs passed in start with --
 /// This function is only intended to be used from glint.execute_root
-pub fn update_flags(
-  in flags: FlagMap,
-  with flag_input: String,
-) -> Result(FlagMap) {
+pub fn update_flags(in flags: Map, with flag_input: String) -> Result(Map) {
   let flag_input = string.drop_left(flag_input, string.length(prefix))
   case string.split_once(flag_input, delimiter) {
     Error(_) -> {
@@ -123,7 +120,7 @@ pub fn update_flags(
 }
 
 /// Gets the current Value for the associated flag
-fn access_flag(flags: FlagMap, name: String) -> Result(Value) {
+fn access_flag(flags: Map, name: String) -> Result(Value) {
   map.get(flags, name)
   |> result.replace_error(undefined_flag_err(name))
 }

--- a/src/glint/flag.gleam
+++ b/src/glint/flag.gleam
@@ -51,19 +51,19 @@ pub fn int(called name: String, default value: Int) -> Flag {
   Flag(name, I(value))
 }
 
+/// Creates a Flag(name, LI(value))
+pub fn ints(called name: String, default value: List(Int)) -> Flag {
+  Flag(name, LI(value))
+}
+
 /// Creates a Flag(name, F(value))
 pub fn float(called name: String, default value: Float) -> Flag {
   Flag(name, F(value))
 }
 
 /// Creates a Flag(name, LF(value))
-pub fn float_list(called name: String, default value: List(Float)) -> Flag {
+pub fn floats(called name: String, default value: List(Float)) -> Flag {
   Flag(name, LF(value))
-}
-
-/// Creates a Flag(name, LI(value))
-pub fn int_list(called name: String, default value: List(Int)) -> Flag {
-  Flag(name, LI(value))
 }
 
 /// Creates a Flag(name, S(value))
@@ -72,7 +72,7 @@ pub fn string(called name: String, default value: String) -> Flag {
 }
 
 /// Creates a Flag(name, LS(value))
-pub fn string_list(called name: String, default value: List(String)) -> Flag {
+pub fn strings(called name: String, default value: List(String)) -> Flag {
   Flag(name, LS(value))
 }
 

--- a/src/glint/flag.gleam
+++ b/src/glint/flag.gleam
@@ -16,7 +16,7 @@ pub const prefix = "--"
 const delimiter = "="
 
 /// Supported flag types.
-pub type FlagValue {
+pub type Value {
   /// Boolean flags, to be passed in as `--flag=true` or `--flag=false`.
   /// Can be toggled by omitting the desired value like `--flag`.
   /// Toggling will negate the existing value.
@@ -43,7 +43,7 @@ pub type FlagValue {
 
 /// Associates a name with a flag value
 pub type Flag {
-  Flag(name: String, value: FlagValue)
+  Flag(name: String, value: Value)
 }
 
 /// Creates a Flag(name, I(value))
@@ -83,7 +83,7 @@ pub fn bool(called name: String, default value: Bool) -> Flag {
 
 /// Associate flag names to their current values.
 pub type FlagMap =
-  Map(String, FlagValue)
+  Map(String, Value)
 
 /// Convert a list of flags to a FlagMap.
 pub fn build_map(flags: List(Flag)) -> FlagMap {
@@ -122,8 +122,8 @@ pub fn update_flags(
   }
 }
 
-/// Gets the current FlagValue for the associated flag
-fn access_flag(flags: FlagMap, name: String) -> Result(FlagValue) {
+/// Gets the current Value for the associated flag
+fn access_flag(flags: FlagMap, name: String) -> Result(Value) {
   map.get(flags, name)
   |> result.replace_error(undefined_flag_err(name))
 }
@@ -132,8 +132,8 @@ fn access_flag(flags: FlagMap, name: String) -> Result(FlagValue) {
 fn compute_flag(
   for name: String,
   with value: String,
-  given default: FlagValue,
-) -> Result(FlagValue) {
+  given default: Value,
+) -> Result(Value) {
   case default {
     I(_) -> parse_int
     LI(_) -> parse_int_list
@@ -188,8 +188,8 @@ fn parse_string_list(_key, value) {
 fn parse_flag(
   value: String,
   parse: fn(String) -> gleam.Result(a, b),
-  construct: fn(a) -> FlagValue,
-) -> gleam.Result(FlagValue, b) {
+  construct: fn(a) -> Value,
+) -> gleam.Result(Value, b) {
   value
   |> parse()
   |> result.map(construct)
@@ -198,8 +198,8 @@ fn parse_flag(
 fn parse_list_flag(
   value: String,
   parse: fn(String) -> gleam.Result(a, b),
-  construct: fn(List(a)) -> FlagValue,
-) -> gleam.Result(FlagValue, b) {
+  construct: fn(List(a)) -> Value,
+) -> gleam.Result(Value, b) {
   value
   |> string.split(",")
   |> list.try_map(parse)

--- a/test/flag_test.gleam
+++ b/test/flag_test.gleam
@@ -8,11 +8,11 @@ pub fn update_flag_test() {
     [
       flag.bool("bflag", False),
       flag.string("sflag", "default"),
-      flag.string_list("lsflag", ["a", "b", "c"]),
+      flag.strings("lsflag", ["a", "b", "c"]),
       flag.int("iflag", 0),
-      flag.int_list("liflag", [0, 1, 2, 3]),
+      flag.ints("liflag", [0, 1, 2, 3]),
       flag.float("fflag", 1.0),
-      flag.float_list("lfflag", [0.0, 1.0, 2.0]),
+      flag.floats("lfflag", [0.0, 1.0, 2.0]),
     ]
     |> flag.build_map()
 
@@ -177,8 +177,8 @@ pub fn bool_flag_test() {
   |> should.be_ok()
 }
 
-pub fn string_list_flag_test() {
-  let flags = flag.string_list("flag", ["val1", "val2"])
+pub fn strings_flag_test() {
+  let flags = flag.strings("flag", ["val1", "val2"])
   let flag_input = "--flag=val3,val4"
   let expect_flag_value_list = fn(in: CommandInput) {
     in.flags
@@ -191,8 +191,8 @@ pub fn string_list_flag_test() {
   |> should.be_ok()
 }
 
-pub fn int_list_flag_test() {
-  let flags = flag.int_list("flag", [1, 2])
+pub fn ints_flag_test() {
+  let flags = flag.ints("flag", [1, 2])
 
   // fails to parse input for flag as int list, returns error
   let flag_input = "--flag=val3,val4"
@@ -238,8 +238,8 @@ pub fn float_flag_test() {
   |> should.be_ok()
 }
 
-pub fn float_list_flag_test() {
-  let flags = flag.float_list("flag", [1.0, 2.0])
+pub fn floats_flag_test() {
+  let flags = flag.floats("flag", [1.0, 2.0])
 
   // fails to parse input for flag as float list, returns error
   let flag_input = "--flag=val3,val4"


### PR DESCRIPTION
- #4 
- rename `flag.FlagValue` to `flag.Value`
- rename `flag.FlagMap` to `flag.Map`