### PR TITLE
Align and wrap description, usage, flags, and commands

### DIFF
--- a/birdie_snapshots/cmd1_help.accepted
+++ b/birdie_snapshots/cmd1_help.accepted
@@ -11,14 +11,16 @@ Command: cmd1
 This is cmd1
 
 USAGE:
-	gleam run -m test cmd1 ( cmd3 | cmd4 ) [ ARGS ] [ --flag2=<INT> --flag5=<FLOAT_LIST> --global=<STRING> ]
+	gleam run -m test cmd1 ( cmd3 | cmd4 ) [ ARGS ] [ --flag2=<INT> --flag5=<FLOAT_LIST>
+	  --global=<STRING> ]
 
 FLAGS:
-	--flag2=<INT>		This is flag2
-	--flag5=<FLOAT_LIST>		This is flag5
-	--global=<STRING>		This is a global flag
-	--help			Print help information
+	--flag2=<INT>             This is flag2
+	--flag5=<FLOAT_LIST>      This is flag5 with a really really really really really really
+	                          long description
+	--global=<STRING>         This is a global flag
+	--help                    Print help information
 
 SUBCOMMANDS:
-	cmd3		This is cmd3
-	cmd4		This is cmd4
+	cmd3                      This is cmd3
+	cmd4                      This is cmd4

--- a/birdie_snapshots/cmd1_help.accepted
+++ b/birdie_snapshots/cmd1_help.accepted
@@ -11,16 +11,18 @@ Command: cmd1
 This is cmd1
 
 USAGE:
-	gleam run -m test cmd1 ( cmd3 | cmd4 ) [ ARGS ] [ --flag2=<INT> --flag5=<FLOAT_LIST>
-	  --global=<STRING> ]
+	gleam run -m test cmd1 ( cmd3 | cmd4 ) [ ARGS ] [ --flag2=<INT>
+	  --global=<STRING> --very-very-very-long-flag=<FLOAT_LIST> ]
 
 FLAGS:
-	--flag2=<INT>             This is flag2
-	--flag5=<FLOAT_LIST>      This is flag5 with a really really really really really really
-	                          long description
-	--global=<STRING>         This is a global flag
-	--help                    Print help information
+	--flag2=<INT>                            This is flag2
+	--global=<STRING>                        This is a global flag
+	--help                                   Print help information
+	--very-very-very-long-flag=<FLOAT_LIST>  This is a very long flag with a
+	                                         very very very very very very
+	                                         long description
 
 SUBCOMMANDS:
-	cmd3                      This is cmd3
-	cmd4                      This is cmd4
+	cmd3                  This is cmd3
+	cmd4                  This is cmd4 which has a very very very very very
+	                      very very very long description

--- a/birdie_snapshots/cmd1_help.accepted
+++ b/birdie_snapshots/cmd1_help.accepted
@@ -11,18 +11,18 @@ Command: cmd1
 This is cmd1
 
 USAGE:
-	gleam run -m test cmd1 ( cmd3 | cmd4 ) [ ARGS ] [ --flag2=<INT>
-	  --global=<STRING> --very-very-very-long-flag=<FLOAT_LIST> ]
+    gleam run -m test cmd1 ( cmd3 | cmd4 ) [ ARGS ] [ --flag2=<INT>
+        --global=<STRING> --very-very-very-long-flag=<FLOAT_LIST> ]
 
 FLAGS:
-	--flag2=<INT>                            This is flag2
-	--global=<STRING>                        This is a global flag
-	--help                                   Print help information
-	--very-very-very-long-flag=<FLOAT_LIST>  This is a very long flag with a
-	                                         very very very very very very
-	                                         long description
+    --flag2=<INT>                            This is flag2
+    --global=<STRING>                        This is a global flag
+    --help                                   Print help information
+    --very-very-very-long-flag=<FLOAT_LIST>  This is a very long flag with a
+                                             very very very very very very long
+                                             description
 
 SUBCOMMANDS:
-	cmd3                  This is cmd3
-	cmd4                  This is cmd4 which has a very very very very very
-	                      very very very long description
+    cmd3                  This is cmd3
+    cmd4                  This is cmd4 which has a very very very very very very
+                          very very long description

--- a/birdie_snapshots/cmd2_help.accepted
+++ b/birdie_snapshots/cmd2_help.accepted
@@ -11,8 +11,8 @@ Command: cmd2
 This is cmd2
 
 USAGE:
-	gleam run -m test cmd2 <arg1> <arg2> [ --global=<STRING> ]
+    gleam run -m test cmd2 <arg1> <arg2> [ --global=<STRING> ]
 
 FLAGS:
-	--global=<STRING>     This is a global flag
-	--help                Print help information
+    --global=<STRING>     This is a global flag
+    --help                Print help information

--- a/birdie_snapshots/cmd2_help.accepted
+++ b/birdie_snapshots/cmd2_help.accepted
@@ -14,5 +14,5 @@ USAGE:
 	gleam run -m test cmd2 <arg1> <arg2> [ --global=<STRING> ]
 
 FLAGS:
-	--global=<STRING>		This is a global flag
-	--help			Print help information
+	--global=<STRING>         This is a global flag
+	--help                    Print help information

--- a/birdie_snapshots/cmd2_help.accepted
+++ b/birdie_snapshots/cmd2_help.accepted
@@ -14,5 +14,5 @@ USAGE:
 	gleam run -m test cmd2 <arg1> <arg2> [ --global=<STRING> ]
 
 FLAGS:
-	--global=<STRING>         This is a global flag
-	--help                    Print help information
+	--global=<STRING>     This is a global flag
+	--help                Print help information

--- a/birdie_snapshots/cmd3_help.accepted
+++ b/birdie_snapshots/cmd3_help.accepted
@@ -11,10 +11,10 @@ Command: cmd1 cmd3
 This is cmd3
 
 USAGE:
-	gleam run -m test cmd1 cmd3 <woo> [ 2 or more arguments ] [ --flag3=<BOOL>
-	  --global=<STRING> ]
+	gleam run -m test cmd1 cmd3 <woo> [ 2 or more arguments ] [
+	  --flag3=<BOOL> --global=<STRING> ]
 
 FLAGS:
-	--flag3=<BOOL>            This is flag3
-	--global=<STRING>         This is a global flag
-	--help                    Print help information
+	--flag3=<BOOL>        This is flag3
+	--global=<STRING>     This is a global flag
+	--help                Print help information

--- a/birdie_snapshots/cmd3_help.accepted
+++ b/birdie_snapshots/cmd3_help.accepted
@@ -11,9 +11,10 @@ Command: cmd1 cmd3
 This is cmd3
 
 USAGE:
-	gleam run -m test cmd1 cmd3 <woo> [ 2 or more arguments ] [ --flag3=<BOOL> --global=<STRING> ]
+	gleam run -m test cmd1 cmd3 <woo> [ 2 or more arguments ] [ --flag3=<BOOL>
+	  --global=<STRING> ]
 
 FLAGS:
-	--flag3=<BOOL>		This is flag3
-	--global=<STRING>		This is a global flag
-	--help			Print help information
+	--flag3=<BOOL>            This is flag3
+	--global=<STRING>         This is a global flag
+	--help                    Print help information

--- a/birdie_snapshots/cmd3_help.accepted
+++ b/birdie_snapshots/cmd3_help.accepted
@@ -11,10 +11,10 @@ Command: cmd1 cmd3
 This is cmd3
 
 USAGE:
-	gleam run -m test cmd1 cmd3 <woo> [ 2 or more arguments ] [
-	  --flag3=<BOOL> --global=<STRING> ]
+    gleam run -m test cmd1 cmd3 <woo> [ 2 or more arguments ] [ --flag3=<BOOL>
+        --global=<STRING> ]
 
 FLAGS:
-	--flag3=<BOOL>        This is flag3
-	--global=<STRING>     This is a global flag
-	--help                Print help information
+    --flag3=<BOOL>        This is flag3
+    --global=<STRING>     This is a global flag
+    --help                Print help information

--- a/birdie_snapshots/cmd4_help.accepted
+++ b/birdie_snapshots/cmd4_help.accepted
@@ -12,9 +12,9 @@ This is cmd4 which has a very very very very very very very very long
 description
 
 USAGE:
-	gleam run -m test cmd1 cmd4 [ --flag4=<FLOAT> --global=<STRING> ]
+    gleam run -m test cmd1 cmd4 [ --flag4=<FLOAT> --global=<STRING> ]
 
 FLAGS:
-	--flag4=<FLOAT>       This is flag4
-	--global=<STRING>     This is a global flag
-	--help                Print help information
+    --flag4=<FLOAT>       This is flag4
+    --global=<STRING>     This is a global flag
+    --help                Print help information

--- a/birdie_snapshots/cmd4_help.accepted
+++ b/birdie_snapshots/cmd4_help.accepted
@@ -8,12 +8,13 @@ Some awesome global help text!
 
 Command: cmd1 cmd4
 
-This is cmd4
+This is cmd4 which has a very very very very very very very very long
+description
 
 USAGE:
 	gleam run -m test cmd1 cmd4 [ --flag4=<FLOAT> --global=<STRING> ]
 
 FLAGS:
-	--flag4=<FLOAT>           This is flag4
-	--global=<STRING>         This is a global flag
-	--help                    Print help information
+	--flag4=<FLOAT>       This is flag4
+	--global=<STRING>     This is a global flag
+	--help                Print help information

--- a/birdie_snapshots/cmd4_help.accepted
+++ b/birdie_snapshots/cmd4_help.accepted
@@ -14,6 +14,6 @@ USAGE:
 	gleam run -m test cmd1 cmd4 [ --flag4=<FLOAT> --global=<STRING> ]
 
 FLAGS:
-	--flag4=<FLOAT>		This is flag4
-	--global=<STRING>		This is a global flag
-	--help			Print help information
+	--flag4=<FLOAT>           This is flag4
+	--global=<STRING>         This is a global flag
+	--help                    Print help information

--- a/birdie_snapshots/cmd6_help.accepted
+++ b/birdie_snapshots/cmd6_help.accepted
@@ -11,11 +11,11 @@ Command: cmd5 cmd6
 This is cmd6
 
 USAGE:
-	gleam run -m test cmd5 cmd6 ( cmd7 ) [ ARGS ] [ --global=<STRING> ]
+    gleam run -m test cmd5 cmd6 ( cmd7 ) [ ARGS ] [ --global=<STRING> ]
 
 FLAGS:
-	--global=<STRING>     This is a global flag
-	--help                Print help information
+    --global=<STRING>     This is a global flag
+    --help                Print help information
 
 SUBCOMMANDS:
-	cmd7                  This is cmd7
+    cmd7                  This is cmd7

--- a/birdie_snapshots/cmd6_help.accepted
+++ b/birdie_snapshots/cmd6_help.accepted
@@ -14,8 +14,8 @@ USAGE:
 	gleam run -m test cmd5 cmd6 ( cmd7 ) [ ARGS ] [ --global=<STRING> ]
 
 FLAGS:
-	--global=<STRING>         This is a global flag
-	--help                    Print help information
+	--global=<STRING>     This is a global flag
+	--help                Print help information
 
 SUBCOMMANDS:
-	cmd7                      This is cmd7
+	cmd7                  This is cmd7

--- a/birdie_snapshots/cmd6_help.accepted
+++ b/birdie_snapshots/cmd6_help.accepted
@@ -14,8 +14,8 @@ USAGE:
 	gleam run -m test cmd5 cmd6 ( cmd7 ) [ ARGS ] [ --global=<STRING> ]
 
 FLAGS:
-	--global=<STRING>		This is a global flag
-	--help			Print help information
+	--global=<STRING>         This is a global flag
+	--help                    Print help information
 
 SUBCOMMANDS:
-	cmd7		This is cmd7
+	cmd7                      This is cmd7

--- a/birdie_snapshots/cmd7_help.accepted
+++ b/birdie_snapshots/cmd7_help.accepted
@@ -11,4 +11,4 @@ Command: cmd5 cmd6 cmd7
 This is cmd7
 
 USAGE:
-	gleam run -m test cmd5 cmd6 cmd7 [ ARGS ]
+    gleam run -m test cmd5 cmd6 cmd7 [ ARGS ]

--- a/birdie_snapshots/root_help.accepted
+++ b/birdie_snapshots/root_help.accepted
@@ -9,14 +9,15 @@ Some awesome global help text!
 This is the root command
 
 USAGE:
-	gleam run -m test ( cmd1 | cmd2 | cmd5 ) <arg1> <arg2> [ ARGS ] [ --flag1=<STRING> --global=<STRING> ]
+	gleam run -m test ( cmd1 | cmd2 | cmd5 ) <arg1> <arg2> [ ARGS ] [ --flag1=<STRING>
+	  --global=<STRING> ]
 
 FLAGS:
-	--flag1=<STRING>		This is flag1
-	--global=<STRING>		This is a global flag
-	--help			Print help information
+	--flag1=<STRING>          This is flag1
+	--global=<STRING>         This is a global flag
+	--help                    Print help information
 
 SUBCOMMANDS:
-	cmd1		This is cmd1
-	cmd2		This is cmd2
-	cmd5
+	cmd1                      This is cmd1
+	cmd2                      This is cmd2
+	cmd5                      

--- a/birdie_snapshots/root_help.accepted
+++ b/birdie_snapshots/root_help.accepted
@@ -9,15 +9,17 @@ Some awesome global help text!
 This is the root command
 
 USAGE:
-	gleam run -m test ( cmd1 | cmd2 | cmd5 ) <arg1> <arg2> [ ARGS ] [ --flag1=<STRING>
-	  --global=<STRING> ]
+	gleam run -m test ( cmd1 | cmd2 | cmd5 | cmd8-very-very-very-very-long
+	  ) <arg1> <arg2> [ ARGS ] [ --flag1=<STRING> --global=<STRING> ]
 
 FLAGS:
-	--flag1=<STRING>          This is flag1
-	--global=<STRING>         This is a global flag
-	--help                    Print help information
+	--flag1=<STRING>      This is flag1
+	--global=<STRING>     This is a global flag
+	--help                Print help information
 
 SUBCOMMANDS:
-	cmd1                      This is cmd1
-	cmd2                      This is cmd2
-	cmd5                      
+	cmd1                           This is cmd1
+	cmd2                           This is cmd2
+	cmd5                           
+	cmd8-very-very-very-very-long  This is cmd8 with a very very very very
+	                               very very very long description

--- a/birdie_snapshots/root_help.accepted
+++ b/birdie_snapshots/root_help.accepted
@@ -9,17 +9,17 @@ Some awesome global help text!
 This is the root command
 
 USAGE:
-	gleam run -m test ( cmd1 | cmd2 | cmd5 | cmd8-very-very-very-very-long
-	  ) <arg1> <arg2> [ ARGS ] [ --flag1=<STRING> --global=<STRING> ]
+    gleam run -m test ( cmd1 | cmd2 | cmd5 | cmd8-very-very-very-very-long )
+        <arg1> <arg2> [ ARGS ] [ --flag1=<STRING> --global=<STRING> ]
 
 FLAGS:
-	--flag1=<STRING>      This is flag1
-	--global=<STRING>     This is a global flag
-	--help                Print help information
+    --flag1=<STRING>      This is flag1
+    --global=<STRING>     This is a global flag
+    --help                Print help information
 
 SUBCOMMANDS:
-	cmd1                           This is cmd1
-	cmd2                           This is cmd2
-	cmd5                           
-	cmd8-very-very-very-very-long  This is cmd8 with a very very very very
-	                               very very very long description
+    cmd1                           This is cmd1
+    cmd2                           This is cmd2
+    cmd5                           
+    cmd8-very-very-very-very-long  This is cmd8 with a very very very very very
+                                   very very long description

--- a/src/glint/internal/utils.gleam
+++ b/src/glint/internal/utils.gleam
@@ -49,8 +49,8 @@ fn do_wordwrap(
       }
     }
 
-    // There are no more more tokens, so add the current line to the result if
-    // it's not empty
+    // There are no more tokens so return the final result, adding the current
+    // line to it if it's not empty
     [] if line == "" -> list.reverse(lines)
     [] -> list.reverse([line, ..lines])
   }

--- a/src/glint/internal/utils.gleam
+++ b/src/glint/internal/utils.gleam
@@ -1,0 +1,57 @@
+import gleam/int
+import gleam/list
+import gleam/string
+
+/// Returns the length of the longest string in the list.
+///
+pub fn max_string_length(strings: List(String)) -> Int {
+  strings |> list.fold(0, fn(max, f) { f |> string.length |> int.max(max) })
+}
+
+/// Wraps the given string so that no lines exceed the given width. Newlines in
+/// the input string are retained.
+///
+pub fn wordwrap(s: String, max_width: Int) -> List(String) {
+  s
+  |> string.split("\n")
+  |> list.map(fn(s) {
+    s
+    |> string.split(" ")
+    |> do_wordwrap(max_width, "", [])
+  })
+  |> list.flatten
+}
+
+fn do_wordwrap(
+  tokens: List(String),
+  max_width: Int,
+  current_line: String,
+  lines: List(String),
+) -> List(String) {
+  case tokens {
+    [] ->
+      case current_line {
+        "" -> lines
+        _ -> [current_line, ..lines]
+      }
+      |> list.reverse
+
+    [token, ..new_tokens] -> {
+      let line_length = string.length(current_line)
+      let token_length = string.length(token)
+
+      case line_length {
+        0 -> do_wordwrap(new_tokens, max_width, token, lines)
+        _ ->
+          case line_length + 1 + token_length <= max_width {
+            True -> {
+              let current_line = current_line <> " " <> token
+              do_wordwrap(new_tokens, max_width, current_line, lines)
+            }
+
+            False -> do_wordwrap(tokens, max_width, "", [current_line, ..lines])
+          }
+      }
+    }
+  }
+}

--- a/src/glint/internal/utils.gleam
+++ b/src/glint/internal/utils.gleam
@@ -5,53 +5,53 @@ import gleam/string
 /// Returns the length of the longest string in the list.
 ///
 pub fn max_string_length(strings: List(String)) -> Int {
-  strings |> list.fold(0, fn(max, f) { f |> string.length |> int.max(max) })
+  use max, f <- list.fold(strings, 0)
+
+  f
+  |> string.length
+  |> int.max(max)
 }
 
 /// Wraps the given string so that no lines exceed the given width. Newlines in
 /// the input string are retained.
 ///
 pub fn wordwrap(s: String, max_width: Int) -> List(String) {
-  s
-  |> string.split("\n")
-  |> list.map(fn(s) {
-    s
-    |> string.split(" ")
-    |> do_wordwrap(max_width, "", [])
-  })
-  |> list.flatten
+  use line <- list.flat_map(string.split(s, "\n"))
+
+  line
+  |> string.split(" ")
+  |> do_wordwrap(max_width, "", [])
 }
 
 fn do_wordwrap(
   tokens: List(String),
   max_width: Int,
-  current_line: String,
+  line: String,
   lines: List(String),
 ) -> List(String) {
   case tokens {
-    [] ->
-      case current_line {
-        "" -> lines
-        _ -> [current_line, ..lines]
-      }
-      |> list.reverse
-
-    [token, ..new_tokens] -> {
-      let line_length = string.length(current_line)
+    // Handle the next token
+    [token, ..tokens] -> {
       let token_length = string.length(token)
+      let line_length = string.length(line)
 
-      case line_length {
-        0 -> do_wordwrap(new_tokens, max_width, token, lines)
-        _ ->
-          case line_length + 1 + token_length <= max_width {
-            True -> {
-              let current_line = current_line <> " " <> token
-              do_wordwrap(new_tokens, max_width, current_line, lines)
-            }
+      case line, line_length + 1 + token_length <= max_width {
+        // When the current line is empty the next token always goes on it
+        // regardless of its length
+        "", _ -> do_wordwrap(tokens, max_width, token, lines)
 
-            False -> do_wordwrap(tokens, max_width, "", [current_line, ..lines])
-          }
+        // Add the next token to the current line if it fits
+        _, True -> do_wordwrap(tokens, max_width, line <> " " <> token, lines)
+
+        // Start a new line with the next token as it exceeds the max width if
+        // added to the current line
+        _, False -> do_wordwrap(tokens, max_width, token, [line, ..lines])
       }
     }
+
+    // There are no more more tokens, so add the current line to the result if
+    // it's not empty
+    [] if line == "" -> list.reverse(lines)
+    [] -> list.reverse([line, ..lines])
   }
 }

--- a/test/examples/hello.gleam
+++ b/test/examples/hello.gleam
@@ -29,15 +29,15 @@
 //// Prints Hello, <names>!
 ////
 //// USAGE:
-//// 	gleam run -m examples/hello ( single ) [ 1 or more arguments ] [ --caps=<BOOL> --repeat=<INT> ]
+////         gleam run -m examples/hello ( single ) [ 1 or more arguments ] [ --caps=<BOOL> --repeat=<INT> ]
 ////
 //// FLAGS:
-//// 	--caps=<BOOL>		Capitalize the hello message
-//// 	--help			Print help information
-//// 	--repeat=<INT>		Repeat the message n-times
+////         --caps=<BOOL>       Capitalize the hello message
+////         --help              Print help information
+////         --repeat=<INT>      Repeat the message n-times
 ////
 //// SUBCOMMANDS:
-//// 	single		Prints Hello, <name>!
+////         single              Prints Hello, <name>!
 //// ```
 ////
 //// Here is the help text for the `single` command:
@@ -50,12 +50,12 @@
 //// Prints Hello, <name>!
 ////
 //// USAGE:
-//// 	gleam run -m examples/hello single <name> [ --caps=<BOOL> --repeat=<INT> ]
+////         gleam run -m examples/hello single <name> [ --caps=<BOOL> --repeat=<INT> ]
 ////
 //// FLAGS:
-//// 	--caps=<BOOL>		Capitalize the hello message
-//// 	--help			Print help information
-//// 	--repeat=<INT>		Repeat the message n-times
+////         --caps=<BOOL>       Capitalize the hello message
+////         --help              Print help information
+////         --repeat=<INT>      Repeat the message n-times
 //// ```
 
 // stdlib imports

--- a/test/glint_test.gleam
+++ b/test/glint_test.gleam
@@ -10,10 +10,7 @@ pub fn main() {
 
 pub fn path_clean_test() {
   glint.new()
-  |> glint.add(
-    ["", " ", " cmd", "subcmd\t"],
-    glint.command(fn(_, _, _) { Nil }),
-  )
+  |> glint.add(["", " ", " cmd", "subcmd"], glint.command(fn(_, _, _) { Nil }))
   |> glint.execute(["cmd", "subcmd"])
   |> should.be_ok()
 }

--- a/test/glint_test.gleam
+++ b/test/glint_test.gleam
@@ -122,10 +122,10 @@ pub fn help_test() {
     |> glint.flag_help("This is flag4")
 
   let flag_5 =
-    "flag5"
+    "very-very-very-long-flag"
     |> glint.floats_flag()
     |> glint.flag_help(
-      "This is flag5 with a really really really really really really long description",
+      "This is a very long flag with a very very very very very very long description",
     )
 
   let cli =
@@ -155,7 +155,9 @@ pub fn help_test() {
       glint.command(nil)
     })
     |> glint.add(at: ["cmd1", "cmd4"], do: {
-      use <- glint.command_help("This is cmd4")
+      use <- glint.command_help(
+        "This is cmd4 which has a very very very very very very very very long description",
+      )
       use _flag4 <- glint.flag(flag_4)
       use <- glint.unnamed_args(glint.EqArgs(0))
       glint.command(nil)
@@ -172,6 +174,10 @@ pub fn help_test() {
       do: glint.command_help("This is cmd6", fn() { glint.command(nil) }),
     )
     |> glint.path_help(["cmd5", "cmd6", "cmd7"], "This is cmd7")
+    |> glint.path_help(
+      ["cmd8-very-very-very-very-long"],
+      "This is cmd8 with a very very very very very very very long description",
+    )
 
   // execute root command
   glint.execute(cli, ["a", "b"])

--- a/test/glint_test.gleam
+++ b/test/glint_test.gleam
@@ -10,7 +10,10 @@ pub fn main() {
 
 pub fn path_clean_test() {
   glint.new()
-  |> glint.add(["", " ", " cmd", "subcmd"], glint.command(fn(_, _, _) { Nil }))
+  |> glint.add(
+    ["", " ", " cmd", "subcmd\t"],
+    glint.command(fn(_, _, _) { Nil }),
+  )
   |> glint.execute(["cmd", "subcmd"])
   |> should.be_ok()
 }

--- a/test/glint_test.gleam
+++ b/test/glint_test.gleam
@@ -124,7 +124,9 @@ pub fn help_test() {
   let flag_5 =
     "flag5"
     |> glint.floats_flag()
-    |> glint.flag_help("This is flag5")
+    |> glint.flag_help(
+      "This is flag5 with a really really really really really really long description",
+    )
 
   let cli =
     glint.new()


### PR DESCRIPTION
- Wraps all help output to a max width.
- New config options for max output width (default 80 chars), min first column width (default 2 spaces), and column gap (default 2 spaces).
- Flag and command names and descriptions are now aligned and descriptions wrap onto multiple lines
- Usage text also wraps
- Snapshot tests updated to include the above

Could also consider adding a blank line between each command and/or flag. Maybe it should be configurable?