### PR TITLE
Support short flags

### DIFF
--- a/birdie_snapshots/cmd1_help.accepted
+++ b/birdie_snapshots/cmd1_help.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.1.5
+version: 2.0.0
 title: cmd1 help
 file: ./test/glint_test.gleam
 test_name: cmd1_help_test
@@ -15,15 +15,15 @@ USAGE:
         --global=<STRING> --very-very-very-long-flag=<FLOAT_LIST> ]
 
 FLAGS:
-    --flag2=<INT>                            This is flag2
+        --flag2=<INT>                        This is flag2
 
-    --global=<STRING>                        This is a global flag
+        --global=<STRING>                    This is a global flag
 
-    --help                                   Print help information
-
-    --very-very-very-long-flag=<FLOAT_LIST>  This is a very long flag with a
+        --very-very-very-long-flag=<FLOAT_LIST>This is a very long flag with a
                                              very very very very very very long
                                              description
+
+    -h, --help                               Print help information
 
 SUBCOMMANDS:
     cmd3                  This is cmd3

--- a/birdie_snapshots/cmd2_help.accepted
+++ b/birdie_snapshots/cmd2_help.accepted
@@ -1,8 +1,8 @@
 ---
-version: 1.1.5
+version: 2.0.0
 title: cmd2 help
 file: ./test/glint_test.gleam
-test_name: help_test
+test_name: cmd2_help_test
 ---
 Some awesome global help text!
 
@@ -14,5 +14,5 @@ USAGE:
     gleam run -m test cmd2 <arg1> <arg2> [ --global=<STRING> ]
 
 FLAGS:
-    --global=<STRING>     This is a global flag
-    --help                Print help information
+        --global=<STRING> This is a global flag
+    -h, --help            Print help information

--- a/birdie_snapshots/cmd3_help.accepted
+++ b/birdie_snapshots/cmd3_help.accepted
@@ -1,8 +1,8 @@
 ---
-version: 1.1.5
+version: 2.0.0
 title: cmd3 help
 file: ./test/glint_test.gleam
-test_name: help_test
+test_name: cmd3_help_test
 ---
 Some awesome global help text!
 
@@ -15,6 +15,6 @@ USAGE:
         --global=<STRING> ]
 
 FLAGS:
-    --flag3=<BOOL>        This is flag3
-    --global=<STRING>     This is a global flag
-    --help                Print help information
+        --flag3=<BOOL>    This is flag3
+        --global=<STRING> This is a global flag
+    -h, --help            Print help information

--- a/birdie_snapshots/cmd4_help.accepted
+++ b/birdie_snapshots/cmd4_help.accepted
@@ -1,8 +1,8 @@
 ---
-version: 1.1.5
+version: 2.0.0
 title: cmd4 help
 file: ./test/glint_test.gleam
-test_name: help_test
+test_name: cmd4_help_test
 ---
 Some awesome global help text!
 
@@ -15,6 +15,6 @@ USAGE:
     gleam run -m test cmd1 cmd4 [ --flag4=<FLOAT> --global=<STRING> ]
 
 FLAGS:
-    --flag4=<FLOAT>       This is flag4
-    --global=<STRING>     This is a global flag
-    --help                Print help information
+        --flag4=<FLOAT>   This is flag4
+        --global=<STRING> This is a global flag
+    -h, --help            Print help information

--- a/birdie_snapshots/cmd6_help.accepted
+++ b/birdie_snapshots/cmd6_help.accepted
@@ -1,8 +1,8 @@
 ---
-version: 1.1.5
+version: 2.0.0
 title: cmd6 help
 file: ./test/glint_test.gleam
-test_name: help_test
+test_name: cmd6_help_test
 ---
 Some awesome global help text!
 
@@ -14,8 +14,8 @@ USAGE:
     gleam run -m test cmd5 cmd6 ( cmd7 ) [ ARGS ] [ --global=<STRING> ]
 
 FLAGS:
-    --global=<STRING>     This is a global flag
-    --help                Print help information
+        --global=<STRING> This is a global flag
+    -h, --help            Print help information
 
 SUBCOMMANDS:
     cmd7                  This is cmd7

--- a/birdie_snapshots/cmd6_help_with_residual_args.accepted
+++ b/birdie_snapshots/cmd6_help_with_residual_args.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.1.8
+version: 2.0.0
 title: cmd6 help with residual args
 file: ./test/glint_test.gleam
 test_name: call_help_with_residual_args_test
@@ -14,8 +14,8 @@ USAGE:
     gleam run -m test cmd5 cmd6 ( cmd7 ) [ ARGS ] [ --global=<STRING> ]
 
 FLAGS:
-    --global=<STRING>     This is a global flag
-    --help                Print help information
+        --global=<STRING> This is a global flag
+    -h, --help            Print help information
 
 SUBCOMMANDS:
     cmd7                  This is cmd7

--- a/birdie_snapshots/cmd7_help.accepted
+++ b/birdie_snapshots/cmd7_help.accepted
@@ -1,8 +1,8 @@
 ---
-version: 1.1.5
+version: 2.0.0
 title: cmd7 help
 file: ./test/glint_test.gleam
-test_name: help_test
+test_name: cmd7_help_test
 ---
 Some awesome global help text!
 

--- a/birdie_snapshots/root_help.accepted
+++ b/birdie_snapshots/root_help.accepted
@@ -1,5 +1,5 @@
 ---
-version: 1.1.5
+version: 2.0.0
 title: root help
 file: ./test/glint_test.gleam
 test_name: root_help_test
@@ -13,9 +13,9 @@ USAGE:
         <arg1> <arg2> [ ARGS ] [ --flag1=<STRING> --global=<STRING> ]
 
 FLAGS:
-    --flag1=<STRING>      This is flag1
-    --global=<STRING>     This is a global flag
-    --help                Print help information
+        --flag1=<STRING>  This is flag1
+        --global=<STRING> This is a global flag
+    -h, --help            Print help information
 
 SUBCOMMANDS:
     cmd1                           This is cmd1

--- a/src/glint.gleam
+++ b/src/glint.gleam
@@ -1050,6 +1050,17 @@ fn insert(in flags: Flags, at name: String, insert flag: FlagEntry) -> Flags {
   Flags(..flags, internal: dict.insert(flags.internal, name, flag))
 }
 
+fn merge(into a: Flags, from b: Flags) -> Flags {
+  Flags(
+    internal: dict.merge(a.internal, b.internal),
+    shorthands: dict.merge(a.shorthands, b.shorthands),
+  )
+}
+
+fn fold(flags: Flags, acc: acc, f: fn(acc, String, FlagEntry) -> acc) -> acc {
+  dict.fold(flags.internal, acc, f)
+}
+
 fn register_shorthand(
   in flags: Flags,
   at name: Option(String),
@@ -1060,17 +1071,6 @@ fn register_shorthand(
       Flags(..flags, shorthands: dict.insert(flags.shorthands, name, flag_name))
     None -> flags
   }
-}
-
-fn merge(into a: Flags, from b: Flags) -> Flags {
-  Flags(
-    internal: dict.merge(a.internal, b.internal),
-    shorthands: dict.merge(a.shorthands, b.shorthands),
-  )
-}
-
-fn fold(flags: Flags, acc: acc, f: fn(acc, String, FlagEntry) -> acc) -> acc {
-  dict.fold(flags.internal, acc, f)
 }
 
 fn new_flags() -> Flags {
@@ -1088,10 +1088,10 @@ fn update_flags(
   case string.starts_with(flag_input, flag_prefix) {
     True ->
       string.drop_start(flag_input, string.length(flag_prefix))
-      |> update_flags_with_long(flags, _)
+      |> update_flag_from_long(flags, _)
     False ->
       string.drop_start(flag_input, string.length(flag_short_prefix))
-      |> update_flags_with_short(flags, _)
+      |> update_flag_from_short(flags, _)
   }
 }
 
@@ -1099,7 +1099,7 @@ fn update_flags(
 /// Assumes that all flag inputs passed in start with --
 /// This function is only intended to be used from glint.execute_root
 ///
-fn update_flags_with_long(
+fn update_flag_from_long(
   in flags: Flags,
   with flag_input: String,
 ) -> snag.Result(Flags) {
@@ -1113,18 +1113,18 @@ fn update_flags_with_long(
 /// Assumes that all flag inputs passed in start with -
 /// This function is only intended to be used from glint.execute_root
 ///
-fn update_flags_with_short(
+fn update_flag_from_short(
   in flags: Flags,
   with flag_input: String,
 ) -> snag.Result(Flags) {
   case string.split_once(flag_input, flag_delimiter) {
     Ok(#(short, input)) -> {
-      use flag <- result.try(get_flag_from_short(flags, short))
-      update_flag_value(flags, #(flag, input))
+      use key <- result.try(get_flag_key_from_short(flags, short))
+      update_flag_value(flags, #(key, input))
     }
     Error(_) -> {
-      use flag <- result.try(get_flag_from_short(flags, flag_input))
-      attempt_toggle_flag(flags, flag)
+      use key <- result.try(get_flag_key_from_short(flags, flag_input))
+      attempt_toggle_flag(flags, key)
     }
   }
 }
@@ -1163,13 +1163,13 @@ fn attempt_toggle_flag(in flags: Flags, at key: String) -> snag.Result(Flags) {
   }
 }
 
-fn get_flag_from_short(
+fn get_flag_key_from_short(
   in flags: Flags,
   short short: String,
 ) -> snag.Result(String) {
   flags.shorthands
   |> dict.get(short)
-  |> result.replace_error(undefined_flag_short_err(short))
+  |> result.replace_error(undefined_short_flag_err(short))
 }
 
 fn access_type_error(flag_type) {
@@ -1225,7 +1225,7 @@ fn undefined_flag_err(key: String) -> Snag {
   |> layer_invalid_flag(key)
 }
 
-fn undefined_flag_short_err(short: String) -> Snag {
+fn undefined_short_flag_err(short: String) -> Snag {
   "short flag provided but not defined"
   |> snag.new()
   |> layer_invalid_flag(short)

--- a/src/glint.gleam
+++ b/src/glint.gleam
@@ -464,9 +464,15 @@ pub fn group_flag(
 pub fn execute(glint: Glint(a), args: List(String)) -> Result(Out(a), String) {
   // create help flag to check for
   let help_flag = flag_prefix <> help.help_flag.meta.name
+  let help_short_flag = case help.help_flag.short {
+    Some(short) -> Some(flag_short_prefix <> short)
+    None -> None
+  }
 
   // check if help flag is present
-  let #(help, args) = case list.partition(args, fn(s) { s == help_flag }) {
+  let #(help, args) = case
+    list.partition(args, fn(s) { s == help_flag || Some(s) == help_short_flag })
+  {
     // help flag not in args
     #([], args) -> #(False, args)
     // help flag in args

--- a/src/glint.gleam
+++ b/src/glint.gleam
@@ -1026,6 +1026,8 @@ pub fn flag_default(for flag: Flag(a), of default: a) -> Flag(a) {
 
 /// Set the shorthand for a flag.
 ///
+/// If `short` is not exactly one character, no shorthand is set.
+///
 /// ### Example:
 ///
 /// ```gleam
@@ -1034,7 +1036,10 @@ pub fn flag_default(for flag: Flag(a), of default: a) -> Flag(a) {
 /// ```
 ///
 pub fn flag_short(for flag: Flag(a), of short: String) -> Flag(a) {
-  Flag(..flag, short: Some(short))
+  case string.length(short) {
+    1 -> Flag(..flag, short: Some(short))
+    _ -> flag
+  }
 }
 
 /// Flags passed as input to a command.

--- a/src/glint.gleam
+++ b/src/glint.gleam
@@ -426,7 +426,11 @@ pub fn flag(
   with f: fn(fn(Flags) -> snag.Result(a)) -> Command(b),
 ) -> Command(b) {
   let cmd = f(flag.getter(_, flag.name))
-  Command(..cmd, flags: insert(cmd.flags, flag.name, build_flag(flag)))
+  Command(
+    ..cmd,
+    flags: insert(cmd.flags, flag.name, build_flag(flag))
+      |> register_shorthand(flag.short, flag.name),
+  )
 }
 
 /// Add a flag for a group of commands.
@@ -440,7 +444,8 @@ pub fn group_flag(
   use node <- update_at(in: glint, at: path)
   CommandNode(
     ..node,
-    group_flags: insert(node.group_flags, flag.name, build_flag(flag)),
+    group_flags: insert(node.group_flags, flag.name, build_flag(flag))
+      |> register_shorthand(flag.short, flag.name),
   )
 }
 
@@ -469,7 +474,11 @@ pub fn execute(glint: Glint(a), args: List(String)) -> Result(Out(a), String) {
   }
 
   // split flags out from the args list
-  let #(flags, args) = list.partition(args, string.starts_with(_, flag_prefix))
+  let #(flags, args) =
+    list.partition(args, fn(s) {
+      string.starts_with(s, flag_prefix)
+      || string.starts_with(s, flag_short_prefix)
+    })
 
   // search for command and execute
   do_execute(glint.cmd, glint.config, args, flags, help, [])
@@ -760,6 +769,9 @@ const flag_prefix = "--"
 /// The separation character for flag names and their values
 const flag_delimiter = "="
 
+/// Short flags must start with this prefix
+const flag_short_prefix = "-"
+
 /// Supported flag types.
 ///
 type Value {
@@ -808,6 +820,7 @@ type Value {
 pub opaque type Flag(a) {
   Flag(
     name: String,
+    short: Option(String),
     desc: String,
     parser: Parser(a, Snag),
     value: fn(FlagInternals(a)) -> Value,
@@ -901,6 +914,7 @@ fn new_builder(
 ) -> Flag(a) {
   Flag(
     name: name,
+    short: None,
     desc: "",
     parser: p,
     value: valuer,
@@ -1010,18 +1024,49 @@ pub fn flag_default(for flag: Flag(a), of default: a) -> Flag(a) {
   Flag(..flag, default: Some(default))
 }
 
+/// Set the shorthand for a flag.
+///
+/// ### Example:
+///
+/// ```gleam
+/// glint.int_flag("awesome_flag")
+/// |> glint.flag_short("a")
+/// ```
+///
+pub fn flag_short(for flag: Flag(a), of short: String) -> Flag(a) {
+  Flag(..flag, short: Some(short))
+}
+
 /// Flags passed as input to a command.
 ///
 pub opaque type Flags {
-  Flags(internal: dict.Dict(String, FlagEntry))
+  Flags(
+    internal: dict.Dict(String, FlagEntry),
+    shorthands: dict.Dict(String, String),
+  )
 }
 
 fn insert(in flags: Flags, at name: String, insert flag: FlagEntry) -> Flags {
-  Flags(dict.insert(flags.internal, name, flag))
+  Flags(..flags, internal: dict.insert(flags.internal, name, flag))
+}
+
+fn register_shorthand(
+  in flags: Flags,
+  at name: Option(String),
+  insert flag_name: String,
+) -> Flags {
+  case name {
+    Some(name) ->
+      Flags(..flags, shorthands: dict.insert(flags.shorthands, name, flag_name))
+    None -> flags
+  }
 }
 
 fn merge(into a: Flags, from b: Flags) -> Flags {
-  Flags(internal: dict.merge(a.internal, b.internal))
+  Flags(
+    internal: dict.merge(a.internal, b.internal),
+    shorthands: dict.merge(a.shorthands, b.shorthands),
+  )
 }
 
 fn fold(flags: Flags, acc: acc, f: fn(acc, String, FlagEntry) -> acc) -> acc {
@@ -1029,22 +1074,58 @@ fn fold(flags: Flags, acc: acc, f: fn(acc, String, FlagEntry) -> acc) -> acc {
 }
 
 fn new_flags() -> Flags {
-  Flags(dict.new())
+  Flags(dict.new(), dict.new())
 }
 
 /// Updates a flag value, ensuring that the new value can satisfy the required type.
-/// Assumes that all flag inputs passed in start with --
+/// Assumes that all flag inputs passed in start with -- or -
 /// This function is only intended to be used from glint.execute_root
 ///
 fn update_flags(
   in flags: Flags,
   with flag_input: String,
 ) -> snag.Result(Flags) {
-  let flag_input = string.drop_start(flag_input, string.length(flag_prefix))
+  case string.starts_with(flag_input, flag_prefix) {
+    True ->
+      string.drop_start(flag_input, string.length(flag_prefix))
+      |> update_flags_with_long(flags, _)
+    False ->
+      string.drop_start(flag_input, string.length(flag_short_prefix))
+      |> update_flags_with_short(flags, _)
+  }
+}
 
+/// Updates a long flag value, ensuring that the new value can satisfy the required type.
+/// Assumes that all flag inputs passed in start with --
+/// This function is only intended to be used from glint.execute_root
+///
+fn update_flags_with_long(
+  in flags: Flags,
+  with flag_input: String,
+) -> snag.Result(Flags) {
   case string.split_once(flag_input, flag_delimiter) {
     Ok(data) -> update_flag_value(flags, data)
     Error(_) -> attempt_toggle_flag(flags, flag_input)
+  }
+}
+
+/// Updates a flag value based on short flag, ensuring that the new value can satisfy the required type.
+/// Assumes that all flag inputs passed in start with -
+/// This function is only intended to be used from glint.execute_root
+///
+fn update_flags_with_short(
+  in flags: Flags,
+  with flag_input: String,
+) -> snag.Result(Flags) {
+  case string.split_once(flag_input, flag_delimiter) {
+    Ok(#(short, input)) -> {
+      use flag <- result.try(get_flag_from_short(flags, short))
+      update_flag_value(flags, #(flag, input))
+    }
+    Error(_) -> {
+      use flag <- result.try(get_flag_from_short(flags, flag_input))
+      attempt_toggle_flag(flags, flag)
+    }
   }
 }
 
@@ -1069,17 +1150,26 @@ fn attempt_toggle_flag(in flags: Flags, at key: String) -> snag.Result(Flags) {
       |> B
       |> fn(val) { FlagEntry(..contents, value: val) }
       |> dict.insert(into: flags.internal, for: key)
-      |> Flags
+      |> fn(internal) { Flags(..flags, internal: internal) }
       |> Ok
     B(FlagInternals(Some(val), ..) as internal) ->
       FlagInternals(..internal, value: Some(!val))
       |> B
       |> fn(val) { FlagEntry(..contents, value: val) }
       |> dict.insert(into: flags.internal, for: key)
-      |> Flags
+      |> fn(internal) { Flags(..flags, internal: internal) }
       |> Ok
     _ -> Error(no_value_flag_err(key))
   }
+}
+
+fn get_flag_from_short(
+  in flags: Flags,
+  short short: String,
+) -> snag.Result(String) {
+  flags.shorthands
+  |> dict.get(short)
+  |> result.replace_error(undefined_flag_short_err(short))
 }
 
 fn access_type_error(flag_type) {
@@ -1133,6 +1223,12 @@ fn undefined_flag_err(key: String) -> Snag {
   "flag provided but not defined"
   |> snag.new()
   |> layer_invalid_flag(key)
+}
+
+fn undefined_flag_short_err(short: String) -> Snag {
+  "short flag provided but not defined"
+  |> snag.new()
+  |> layer_invalid_flag(short)
 }
 
 fn cannot_parse(with value: String, is kind: String) -> Snag {

--- a/src/glint.gleam
+++ b/src/glint.gleam
@@ -690,6 +690,7 @@ fn build_help_config(config: Config) -> help.Config {
     min_first_column_width: config.min_first_column_width,
     column_gap: config.column_gap,
     flag_prefix: flag_prefix,
+    flag_short_prefix: flag_short_prefix,
     flag_delimiter: flag_delimiter,
   )
 }
@@ -745,6 +746,7 @@ fn build_flags_help(flags: Flags) -> List(help.Flag) {
   [
     help.Flag(
       meta: help.Metadata(name: name, description: flag.description),
+      short: find_short_from_flag_key(flags, name),
       type_: flag_type_info(flag),
     ),
     ..acc
@@ -1175,6 +1177,15 @@ fn get_flag_key_from_short(
   flags.shorthands
   |> dict.get(short)
   |> result.replace_error(undefined_short_flag_err(short))
+}
+
+fn find_short_from_flag_key(in flags: Flags, for name: String) {
+  dict.fold(flags.shorthands, None, fn(acc, short, long) {
+    case long == name {
+      True -> Some(short)
+      False -> acc
+    }
+  })
 }
 
 fn access_type_error(flag_type) {

--- a/src/glint/internal/help.gleam
+++ b/src/glint/internal/help.gleam
@@ -20,7 +20,11 @@ fn heading_style(heading: String, colour: Colour) -> String {
 
 // --- HELP: CONSTANTS ---
 //
-pub const help_flag = Flag(Metadata("help", "Print help information"), "")
+pub const help_flag = Flag(
+  Metadata("help", "Print help information"),
+  Some("h"),
+  "",
+)
 
 const flags_heading = "FLAGS:"
 
@@ -48,6 +52,7 @@ pub type Config {
     min_first_column_width: Int,
     column_gap: Int,
     flag_prefix: String,
+    flag_short_prefix: String,
     flag_delimiter: String,
   )
 }
@@ -61,7 +66,7 @@ pub type Metadata {
 /// Help type for flag metadata
 ///
 pub type Flag {
-  Flag(meta: Metadata, type_: String)
+  Flag(meta: Metadata, short: Option(String), type_: String)
 }
 
 /// Help type for command metadata
@@ -208,7 +213,7 @@ fn flags_help_to_string(help: List(Flag), config: Config) -> String {
   let content =
     to_spaced_indented_string(
       [help_flag, ..help],
-      fn(help) { #(flag_help_to_string(help, config), help.meta.description) },
+      fn(help) { #(flag_help_to_string_with_shorthand(help, config), help.meta.description) },
       longest_flag_length,
       config,
     )
@@ -225,6 +230,16 @@ fn flag_help_to_string(help: Flag, config: Config) -> String {
     "" -> ""
     _ -> config.flag_delimiter <> "<" <> help.type_ <> ">"
   }
+}
+
+/// generate the help text for a flag with shorthand
+///
+fn flag_help_to_string_with_shorthand(help: Flag, config: Config) -> String {
+  case help.short {
+    Some(short) -> config.flag_short_prefix <> short <> ", "
+    None -> string.repeat(" ", string.length(config.flag_short_prefix) + 3)
+  }
+  <> flag_help_to_string(help, config)
 }
 
 // -- HELP - FUNCTIONS - STRINGIFIERS - SUBCOMMANDS --

--- a/test/flag_test.gleam
+++ b/test/flag_test.gleam
@@ -148,6 +148,17 @@ pub fn flag_short_test() {
   |> glint.add([], expect_flag_value_of_10)
   |> glint.execute([flag_input])
   |> should.be_ok()
+
+  // shorthand is not added if its not exactly one character
+  let flags = glint.int_flag("flag") |> glint.flag_short("ff")
+  let flag_input = "-ff=1"
+  glint.new()
+  |> glint.add(
+    [],
+    glint.flag(flags, fn(_flag) { glint.command(fn(_, _, _) { Nil }) }),
+  )
+  |> glint.execute([flag_input])
+  |> should.be_error()
 }
 
 pub fn flag_value_test() {
@@ -433,7 +444,8 @@ pub fn toggle_test() {
   glint.new()
   |> glint.add([], {
     use flag <- glint.flag(
-      glint.bool_flag("flag") |> glint.flag_short("f")
+      glint.bool_flag("flag")
+      |> glint.flag_short("f")
       |> glint.flag_default(True),
     )
     use _, _, flags <- glint.command()

--- a/test/flag_test.gleam
+++ b/test/flag_test.gleam
@@ -112,6 +112,44 @@ pub fn flag_default_test() {
   |> should.be_ok()
 }
 
+pub fn flag_short_test() {
+  let flags = glint.int_flag("flag") |> glint.flag_short("f")
+
+  // fails to parse input for nonexisting short flag, returns error
+  let flag_input = "-o=X"
+  glint.new()
+  |> glint.add(
+    [],
+    glint.flag(flags, fn(_flag) { glint.command(fn(_, _, _) { Nil }) }),
+  )
+  |> glint.execute([flag_input])
+  |> should.be_error()
+
+  // fails to parse input for flag as int, returns error
+  let flag_input = "-f=X"
+  glint.new()
+  |> glint.add(
+    [],
+    glint.flag(flags, fn(_flag) { glint.command(fn(_, _, _) { Nil }) }),
+  )
+  |> glint.execute([flag_input])
+  |> should.be_error()
+
+  // parses flag input as int, sets value
+  let flag_input = "-f=10"
+  let expect_flag_value_of_10 = {
+    use flag_ <- glint.flag(flags)
+    use _, _, flags <- glint.command()
+    flag_(flags)
+    |> should.equal(Ok(10))
+  }
+
+  glint.new()
+  |> glint.add([], expect_flag_value_of_10)
+  |> glint.execute([flag_input])
+  |> should.be_ok()
+}
+
 pub fn flag_value_test() {
   let args = ["arg1", "arg2"]
   let flag = glint.string_flag("flag")
@@ -382,6 +420,33 @@ pub fn toggle_test() {
   glint.new()
   |> glint.add([], {
     use flag <- glint.flag(glint.bool_flag("flag"))
+    use _, _, flags <- glint.command()
+    flag(flags)
+    |> should.equal(Ok(True))
+  })
+  |> glint.execute([flag_input])
+  |> should.be_ok()
+
+  // boolean flag with default of True is toggled, sets value to False
+  let flag_input = "-f"
+
+  glint.new()
+  |> glint.add([], {
+    use flag <- glint.flag(
+      glint.bool_flag("flag") |> glint.flag_short("f")
+      |> glint.flag_default(True),
+    )
+    use _, _, flags <- glint.command()
+    flag(flags)
+    |> should.equal(Ok(False))
+  })
+  |> glint.execute([flag_input])
+  |> should.be_ok()
+
+  // boolean short flag without default toggled, sets value to True
+  glint.new()
+  |> glint.add([], {
+    use flag <- glint.flag(glint.bool_flag("flag") |> glint.flag_short("f"))
     use _, _, flags <- glint.command()
     flag(flags)
     |> should.equal(Ok(True))


### PR DESCRIPTION
# Add support for short flags

 Fixes #58 

- Add `short: Option(String)` field on `Flag`
- Add shorthands lookup dictionary on `Flags` that maps short flags to regular flags
- Add `flag_short` function to add shorthands to flags

---

I am a bit unsure what the best way is to make sure that short flags are exactly one character. Right now I just ignore them like this if they are invalid:

```gleam
pub fn flag_short(for flag: Flag(a), of short: String) -> Flag(a) {
  case string.length(short) {
    1 -> Flag(..flag, short: Some(short))
    _ -> flag
  }
}
```

It could maybe be good to check it when the CLI execute.

## examples/hello

Here is the repeat flag from the hello example:

```gleam
pub fn repeat_flag() -> glint.Flag(Int) {
  use n <- glint.flag_constraint(
    glint.int_flag("repeat")
    |> glint.flag_short("r") // <---- NEW FUNCTION
    |> glint.flag_default(1)
    |> glint.flag_help("Repeat the message n-times"),
  )
  case n {
    _ if n > 0 -> Ok(n)
    _ -> snag.error("Value must be greater than 0.")
  }
}
```

This is the output we get when we run it with `-h`:

```
gleam run -m examples/hello -- -h
   Compiled in 0.03s
    Running examples/hello.main
It's time to say hello!

Prints Hello, <names>!

USAGE:
    gleam run -m examples/hello ( single ) [ 1 or more arguments ] [
        --caps=<BOOL> --repeat=<INT> ]

FLAGS:
        --caps=<BOOL>     Capitalize the hello message
    -h, --help            Print help information
    -r, --repeat=<INT>    Repeat the message n-times

SUBCOMMANDS:
    single                Prints Hello, <name>!
```

This is what we get when we run with `-r=3`:

```
gleam run -m examples/hello -- World -r=3
   Compiled in 0.04s
    Running examples/hello.main
Hello, World!
Hello, World!
Hello, World!
```