### PR TITLE
feat: expose structured doc tree via document/1 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## [Unreleased](https://github.com/TanklesXL/glint/compare/v1.1.0...HEAD)
 
 - captured each flag's configured default value in the help data
-  (`help.Flag.default`)
+  (`help.Flag.default`) and added the `glint.show_flag_defaults` builder
+  to opt in to rendering `(default: <value>)` in `--help` output
 
 # v1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased](https://github.com/TanklesXL/glint/compare/v1.1.0...HEAD)
 
+- added the `glint.document/1` accessor and the public `glint/help` module,
+  exposing a recursive `Tree` view of the command graph for downstream
+  documentation generators (closes #49). `glint/help.ArgsCount` is declared
+  as a fresh public type with `EqArgs`/`MinArgs` constructors so that
+  downstream documentation tools never need to import `glint/internal/help`
 - captured each flag's configured default value in the help data
   (`help.Flag.default`) and added the `glint.show_flag_defaults` builder
   to opt in to rendering `(default: <value>)` in `--help` output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased](https://github.com/TanklesXL/glint/compare/v1.1.0...HEAD)
 
+- captured each flag's configured default value in the help data
+  (`help.Flag.default`)
+
 # v1
 
 ## [1.3.0](https://github.com/TanklesXL/glint/compare/v1.2.1...v1.3.0)

--- a/README.md
+++ b/README.md
@@ -249,3 +249,56 @@ And here is something that gets its own paragraph.
 In addition to newline formatting, glint also handles wrapping helptext so that it fits within the configured terminal width. This means that if you have a long help text string it will be adjusted to fit on additional lines if it is too long to fit on one line. Spacing is also added to keep descriptions aligned with each other.
 
 There are functions that you can use to tweak glints default wrapping behaviour, but the defaults should be sufficient for the majority of use cases.
+
+
+## Auto-generating documentation
+
+`glint.document/1` returns a recursive `glint/help.Tree` describing every command, flag, and subcommand in a Glint app. Use it to build Markdown, JSON, manpage, or other documentation generators without parsing `--help` output.
+
+```gleam
+import gleam/io
+import gleam/list
+import gleam/option
+import glint
+import glint/help
+
+fn root_command() -> glint.Command(Nil) {
+  use <- glint.command_help("Say hello")
+  glint.command(fn(_, _, _) { Nil })
+}
+
+fn greet_command() -> glint.Command(Nil) {
+  use _name <- glint.flag(
+    glint.string_flag("name")
+    |> glint.flag_default("world")
+    |> glint.flag_help("Name to greet"),
+  )
+  use <- glint.command_help("Greet someone")
+  glint.command(fn(_, _, _) { Nil })
+}
+
+pub fn main() {
+  let app =
+    glint.new()
+    |> glint.with_name("hello")
+    |> glint.add(at: [], do: root_command())
+    |> glint.add(at: ["greet"], do: greet_command())
+
+  let tree: help.Tree = glint.document(app)
+  io.println("Root: " <> tree.meta.description)
+  list.each(tree.subcommands, fn(sub) {
+    io.println(" - " <> sub.meta.name <> ": " <> sub.meta.description)
+    list.each(sub.flags, fn(flag) {
+      io.println("    --" <> flag.meta.name <> " (default: " <>
+        option.unwrap(flag.default, "none") <> ")")
+    })
+  })
+}
+```
+
+The public help types expose these fields:
+
+- `help.Tree(meta: help.Metadata, flags: List(help.Flag), subcommands: List(help.Tree), unnamed_args: Option(help.ArgsCount), named_args: List(String))`
+- `help.Flag(meta: help.Metadata, type_: String, default: Option(String))`
+
+Flag defaults are also surfaced in `--help` output when you opt in with `glint.show_flag_defaults(True)`.

--- a/src/glint.gleam
+++ b/src/glint.gleam
@@ -9,6 +9,7 @@ import gleam/result
 import gleam/string
 import gleam_community/colour.{type Colour}
 import glint/constraint
+import glint/help as pub_help
 import glint/internal/help
 import snag.{type Snag}
 
@@ -705,7 +706,7 @@ fn build_command_help(name: String, node: CommandNode(_)) -> help.Command {
     |> option.map(fn(cmd) {
       #(
         node.description,
-        build_flags_help(merge(node.group_flags, cmd.flags)),
+        build_flags(merge(node.group_flags, cmd.flags)),
         cmd.unnamed_args,
         cmd.named_args,
       )
@@ -713,18 +714,22 @@ fn build_command_help(name: String, node: CommandNode(_)) -> help.Command {
     |> option.unwrap(#(node.description, [], None, []))
 
   help.Command(
-    meta: help.Metadata(name: name, description: description),
+    meta: pub_help.Metadata(name: name, description: description),
     flags: flags,
     subcommands: build_subcommands_help(node.subcommands),
-    unnamed_args: {
-      use args <- option.map(unnamed_args)
-      case args {
-        EqArgs(n) -> help.EqArgs(n)
-        MinArgs(n) -> help.MinArgs(n)
-      }
-    },
+    unnamed_args: to_help_args(unnamed_args),
     named_args: named_args,
   )
+}
+
+/// remap an internal `ArgsCount` to the public `help.ArgsCount`.
+///
+fn to_help_args(args: Option(ArgsCount)) -> Option(pub_help.ArgsCount) {
+  use args <- option.map(args)
+  case args {
+    EqArgs(n) -> pub_help.EqArgs(n)
+    MinArgs(n) -> pub_help.MinArgs(n)
+  }
 }
 
 /// generate the string representation for the type of a flag
@@ -764,13 +769,14 @@ fn join_csv(items: List(a), to_string: fn(a) -> String) -> String {
   items |> list.map(to_string) |> string.join(",")
 }
 
-/// build the help representation for a list of flags
+/// build the public flag representation for a list of flags.
+/// Shared by both `--help` rendering and the `document` doc tree.
 ///
-fn build_flags_help(flags: Flags) -> List(help.Flag) {
+fn build_flags(flags: Flags) -> List(pub_help.Flag) {
   use acc, name, flag <- fold(flags, [])
   [
-    help.Flag(
-      meta: help.Metadata(name: name, description: flag.description),
+    pub_help.Flag(
+      meta: pub_help.Metadata(name: name, description: flag.description),
       type_: flag_type_info(flag),
       default: flag_default_info(flag),
     ),
@@ -782,9 +788,9 @@ fn build_flags_help(flags: Flags) -> List(help.Flag) {
 ///
 fn build_subcommands_help(
   subcommands: dict.Dict(String, CommandNode(_)),
-) -> List(help.Metadata) {
+) -> List(pub_help.Metadata) {
   use acc, name, node <- dict.fold(subcommands, [])
-  [help.Metadata(name: name, description: node.description), ..acc]
+  [pub_help.Metadata(name: name, description: node.description), ..acc]
 }
 
 // ----- FLAGS -----

--- a/src/glint.gleam
+++ b/src/glint.gleam
@@ -729,6 +729,29 @@ fn flag_type_info(flag: FlagEntry) {
   }
 }
 
+fn flag_default_info(flag: FlagEntry) -> Option(String) {
+  case flag.value {
+    I(FlagInternals(value: Some(v), ..)) -> Some(int.to_string(v))
+    F(FlagInternals(value: Some(v), ..)) -> Some(float.to_string(v))
+    S(FlagInternals(value: Some(v), ..)) -> Some(v)
+    B(FlagInternals(value: Some(v), ..)) ->
+      Some(case v {
+        True -> "true"
+        False -> "false"
+      })
+    LI(FlagInternals(value: Some(v), ..)) -> Some(join_csv(v, int.to_string))
+    LF(FlagInternals(value: Some(v), ..)) -> Some(join_csv(v, float.to_string))
+    LS(FlagInternals(value: Some(v), ..)) -> Some(string.join(v, ","))
+    _ -> None
+  }
+}
+
+/// stringify each item and join with commas, for list-flag defaults.
+///
+fn join_csv(items: List(a), to_string: fn(a) -> String) -> String {
+  items |> list.map(to_string) |> string.join(",")
+}
+
 /// build the help representation for a list of flags
 ///
 fn build_flags_help(flags: Flags) -> List(help.Flag) {
@@ -737,6 +760,7 @@ fn build_flags_help(flags: Flags) -> List(help.Flag) {
     help.Flag(
       meta: help.Metadata(name: name, description: flag.description),
       type_: flag_type_info(flag),
+      default: flag_default_info(flag),
     ),
     ..acc
   ]

--- a/src/glint.gleam
+++ b/src/glint.gleam
@@ -29,6 +29,7 @@ type Config {
     max_output_width: Int,
     min_first_column_width: Int,
     column_gap: Int,
+    show_flag_defaults: Bool,
   )
 }
 
@@ -52,6 +53,7 @@ const default_config = Config(
   max_output_width: 80,
   min_first_column_width: 20,
   column_gap: 2,
+  show_flag_defaults: False,
 )
 
 // -- CONFIGURATION: FUNCTIONS --
@@ -125,6 +127,15 @@ pub fn with_min_first_column_width(
 ///
 pub fn with_column_gap(glint: Glint(a), column_gap: Int) -> Glint(a) {
   Glint(..glint, config: Config(..glint.config, column_gap:))
+}
+
+/// Enable rendering of flag default values in `--help` output. When enabled,
+/// each flag with a configured default has `(default: <value>)` appended to
+/// its description.
+///
+/// Disabled by default to preserve existing help text formatting.
+pub fn show_flag_defaults(glint: Glint(a), enabled: Bool) -> Glint(a) {
+  Glint(..glint, config: Config(..glint.config, show_flag_defaults: enabled))
 }
 
 // --- CORE ---
@@ -682,6 +693,7 @@ fn build_help_config(config: Config) -> help.Config {
     column_gap: config.column_gap,
     flag_prefix: flag_prefix,
     flag_delimiter: flag_delimiter,
+    show_flag_defaults: config.show_flag_defaults,
   )
 }
 

--- a/src/glint.gleam
+++ b/src/glint.gleam
@@ -668,6 +668,23 @@ pub fn default_pretty_help() -> PrettyHelp {
 
 // -- HELP: FUNCTIONS --
 
+/// Returns a recursive, structured view of the entire command tree, suitable
+/// for downstream tools that auto-generate reference documentation (Markdown,
+/// JSON, manpages, etc.). See the [`glint/help`](./glint/help.html) module
+/// for the shape of the returned tree.
+///
+/// The tree is taken from the `Glint` builder before execution, so flag
+/// `default` values reflect the values configured via `glint.flag_default`
+/// rather than any runtime-supplied values.
+///
+pub fn document(glint: Glint(a)) -> pub_help.Tree {
+  build_command_tree(
+    option.unwrap(glint.config.name, ""),
+    glint.cmd,
+    new_flags(),
+  )
+}
+
 /// generate the help text for a command
 fn cmd_help(path: List(String), cmd: CommandNode(a), config: Config) -> String {
   // recreate the path of the current command
@@ -730,6 +747,43 @@ fn to_help_args(args: Option(ArgsCount)) -> Option(pub_help.ArgsCount) {
     EqArgs(n) -> pub_help.EqArgs(n)
     MinArgs(n) -> pub_help.MinArgs(n)
   }
+}
+
+/// build the recursive doc tree for the entire command subtree.
+/// Mirrors `build_command_help` but populates `subcommands` recursively
+/// rather than as flat `List(Metadata)`. Used by the public `document` accessor.
+///
+/// `inherited_group_flags` accumulates ancestor group flags so that leaf
+/// commands surface the same effective flag set the runtime resolver applies
+/// in `do_execute` (which propagates `cmd.group_flags` into descendants).
+fn build_command_tree(
+  name: String,
+  node: CommandNode(_),
+  inherited_group_flags: Flags,
+) -> pub_help.Tree {
+  let effective_group_flags = merge(inherited_group_flags, node.group_flags)
+  let #(description, flags, unnamed_args, named_args) =
+    node.contents
+    |> option.map(fn(cmd) {
+      #(
+        node.description,
+        build_flags(merge(effective_group_flags, cmd.flags)),
+        cmd.unnamed_args,
+        cmd.named_args,
+      )
+    })
+    |> option.unwrap(#(node.description, [], None, []))
+
+  pub_help.Tree(
+    meta: pub_help.Metadata(name: name, description: description),
+    flags: flags,
+    subcommands: {
+      use acc, sub_name, sub_node <- dict.fold(node.subcommands, [])
+      [build_command_tree(sub_name, sub_node, effective_group_flags), ..acc]
+    },
+    unnamed_args: to_help_args(unnamed_args),
+    named_args: named_args,
+  )
 }
 
 /// generate the string representation for the type of a flag

--- a/src/glint/help.gleam
+++ b/src/glint/help.gleam
@@ -1,8 +1,9 @@
 //// Stable, public introspection API for glint command trees.
 ////
-//// This module exposes the shared public help types (`Metadata`, `Flag`,
-//// and `ArgsCount`) used when rendering help text and, in future, when
-//// auto-generating reference documentation from a command tree.
+//// This module is intended for tools that auto-generate reference
+//// documentation from a command tree, such as Markdown, JSON, manpages, or
+//// other formats. Use `glint.document/1` as the entry point for producing
+//// these public help values.
 
 import gleam/option.{type Option}
 
@@ -27,4 +28,14 @@ pub type ArgsCount {
 
 pub type Flag {
   Flag(meta: Metadata, type_: String, default: Option(String))
+}
+
+pub type Tree {
+  Tree(
+    meta: Metadata,
+    flags: List(Flag),
+    subcommands: List(Tree),
+    unnamed_args: Option(ArgsCount),
+    named_args: List(String),
+  )
 }

--- a/src/glint/help.gleam
+++ b/src/glint/help.gleam
@@ -1,0 +1,30 @@
+//// Stable, public introspection API for glint command trees.
+////
+//// This module exposes the shared public help types (`Metadata`, `Flag`,
+//// and `ArgsCount`) used when rendering help text and, in future, when
+//// auto-generating reference documentation from a command tree.
+
+import gleam/option.{type Option}
+
+/// Metadata shared by commands and flags: the `name` used in usage text and
+/// headings, plus a human-readable `description`.
+///
+/// Re-declared as a fresh public type (rather than aliasing
+/// `glint/internal/help.Metadata`) so downstream tools can both read and
+/// construct `Metadata` values without importing `glint/internal/help`.
+pub type Metadata {
+  Metadata(name: String, description: String)
+}
+
+/// Number of unnamed positional arguments accepted by a command.
+///
+/// Re-declared (rather than aliased) so that the `EqArgs` and `MinArgs`
+/// constructors are accessible without importing `glint/internal/help`.
+pub type ArgsCount {
+  EqArgs(Int)
+  MinArgs(Int)
+}
+
+pub type Flag {
+  Flag(meta: Metadata, type_: String, default: Option(String))
+}

--- a/src/glint/internal/help.gleam
+++ b/src/glint/internal/help.gleam
@@ -5,6 +5,9 @@ import gleam/option.{type Option, None, Some}
 import gleam/string
 import gleam_community/ansi
 import gleam_community/colour.{type Colour}
+import glint/help.{
+  type ArgsCount, type Flag, type Metadata, EqArgs, Flag, Metadata, MinArgs,
+}
 import glint/internal/utils
 
 /// Style heading text with the provided rgb colouring
@@ -30,11 +33,6 @@ const usage_heading = "USAGE:"
 
 // --- HELP: TYPES ---
 
-pub type ArgsCount {
-  MinArgs(Int)
-  EqArgs(Int)
-}
-
 pub type Config {
   Config(
     name: Option(String),
@@ -51,18 +49,6 @@ pub type Config {
     flag_delimiter: String,
     show_flag_defaults: Bool,
   )
-}
-
-/// Common metadata for commands and flags
-///
-pub type Metadata {
-  Metadata(name: String, description: String)
-}
-
-/// Help type for flag metadata
-///
-pub type Flag {
-  Flag(meta: Metadata, type_: String, default: Option(String))
 }
 
 /// Help type for command metadata

--- a/src/glint/internal/help.gleam
+++ b/src/glint/internal/help.gleam
@@ -49,6 +49,7 @@ pub type Config {
     column_gap: Int,
     flag_prefix: String,
     flag_delimiter: String,
+    show_flag_defaults: Bool,
   )
 }
 
@@ -208,7 +209,15 @@ fn flags_help_to_string(help: List(Flag), config: Config) -> String {
   let content =
     to_spaced_indented_string(
       [help_flag, ..help],
-      fn(help) { #(flag_help_to_string(help, config), help.meta.description) },
+      fn(help) {
+        let description = case config.show_flag_defaults, help.default {
+          True, Some(default) ->
+            help.meta.description <> " (default: " <> default <> ")"
+          _, _ -> help.meta.description
+        }
+
+        #(flag_help_to_string(help, config), description)
+      },
       longest_flag_length,
       config,
     )

--- a/src/glint/internal/help.gleam
+++ b/src/glint/internal/help.gleam
@@ -20,7 +20,7 @@ fn heading_style(heading: String, colour: Colour) -> String {
 
 // --- HELP: CONSTANTS ---
 //
-pub const help_flag = Flag(Metadata("help", "Print help information"), "")
+pub const help_flag = Flag(Metadata("help", "Print help information"), "", None)
 
 const flags_heading = "FLAGS:"
 
@@ -61,7 +61,7 @@ pub type Metadata {
 /// Help type for flag metadata
 ///
 pub type Flag {
-  Flag(meta: Metadata, type_: String)
+  Flag(meta: Metadata, type_: String, default: Option(String))
 }
 
 /// Help type for command metadata

--- a/test/glint/document_test.gleam
+++ b/test/glint/document_test.gleam
@@ -1,0 +1,145 @@
+import gleam/list
+import gleam/option.{None, Some}
+import gleeunit/should
+import glint
+import glint/help
+
+fn nil_command() {
+  glint.command(fn(_, _, _) { Nil })
+}
+
+fn flag_named(flags: List(help.Flag), name: String) -> help.Flag {
+  let assert [flag] = list.filter(flags, fn(flag) { flag.meta.name == name })
+  flag
+}
+
+fn tree_named(trees: List(help.Tree), name: String) -> help.Tree {
+  let assert [tree] = list.filter(trees, fn(tree) { tree.meta.name == name })
+  tree
+}
+
+pub fn empty_glint_documents_empty_tree_test() {
+  let tree = glint.new() |> glint.document
+
+  tree.meta.name
+  |> should.equal("")
+
+  tree.flags
+  |> should.equal([])
+
+  tree.subcommands
+  |> should.equal([])
+
+  tree.unnamed_args
+  |> should.equal(None)
+
+  tree.named_args
+  |> should.equal([])
+}
+
+pub fn with_name_sets_root_tree_name_test() {
+  let tree =
+    glint.new()
+    |> glint.with_name("myapp")
+    |> glint.add(at: [], do: nil_command())
+    |> glint.document
+
+  tree.meta.name
+  |> should.equal("myapp")
+}
+
+pub fn root_command_documents_help_flags_and_defaults_test() {
+  let count =
+    glint.int_flag("count")
+    |> glint.flag_default(3)
+
+  let label =
+    glint.string_flag("label")
+    |> glint.flag_default("fallback")
+
+  let tree =
+    glint.new()
+    |> glint.add(at: [], do: {
+      use <- glint.command_help("Root command description")
+      use _count <- glint.flag(count)
+      use _label <- glint.flag(label)
+      nil_command()
+    })
+    |> glint.document
+
+  tree.meta.description
+  |> should.equal("Root command description")
+
+  list.length(tree.flags)
+  |> should.equal(2)
+
+  let count = flag_named(tree.flags, "count")
+  count.type_
+  |> should.equal("INT")
+  count.default
+  |> should.equal(Some("3"))
+
+  let label = flag_named(tree.flags, "label")
+  label.type_
+  |> should.equal("STRING")
+  label.default
+  |> should.equal(Some("fallback"))
+
+  tree.subcommands
+  |> should.equal([])
+}
+
+pub fn nested_commands_document_recurses_test() {
+  let tree =
+    glint.new()
+    |> glint.add(at: [], do: nil_command())
+    |> glint.add(at: ["one"], do: nil_command())
+    |> glint.add(at: ["one", "two"], do: nil_command())
+    |> glint.add(at: ["one", "two", "three"], do: nil_command())
+    |> glint.document
+
+  list.length(tree.subcommands)
+  |> should.equal(1)
+
+  let one = tree_named(tree.subcommands, "one")
+  one.meta.name
+  |> should.equal("one")
+
+  list.length(one.subcommands)
+  |> should.equal(1)
+
+  let two = tree_named(one.subcommands, "two")
+  two.meta.name
+  |> should.equal("two")
+
+  list.length(two.subcommands)
+  |> should.equal(1)
+
+  let three = tree_named(two.subcommands, "three")
+  three.meta.name
+  |> should.equal("three")
+
+  three.subcommands
+  |> should.equal([])
+}
+
+pub fn group_flags_document_on_leaf_commands_test() {
+  let verbose =
+    glint.string_flag("verbose")
+    |> glint.flag_default("yes")
+
+  let tree =
+    glint.new()
+    |> glint.group_flag(at: ["parent"], of: verbose)
+    |> glint.add(at: ["parent", "leaf"], do: nil_command())
+    |> glint.document
+
+  let parent = tree_named(tree.subcommands, "parent")
+  let leaf = tree_named(parent.subcommands, "leaf")
+  let verbose = flag_named(leaf.flags, "verbose")
+
+  verbose.type_
+  |> should.equal("STRING")
+  verbose.default
+  |> should.equal(Some("yes"))
+}

--- a/test/glint/flag_default_test.gleam
+++ b/test/glint/flag_default_test.gleam
@@ -1,0 +1,82 @@
+import gleam/list
+import gleam/option.{type Option, None, Some}
+import gleeunit/should
+import glint
+
+fn assert_documented_default(
+  flag: glint.Flag(a),
+  name: String,
+  expected: Option(String),
+) {
+  let cmd = {
+    use _ <- glint.flag(flag)
+    glint.command(fn(_, _, _) { Nil })
+  }
+  let g =
+    glint.new()
+    |> glint.add(at: [], do: cmd)
+  let tree = glint.document(g)
+  let assert Ok(f) = list.find(tree.flags, fn(f) { f.meta.name == name })
+
+  f.default
+  |> should.equal(expected)
+}
+
+pub fn int_default_stringifies_test() {
+  glint.int_flag("count")
+  |> glint.flag_default(42)
+  |> assert_documented_default("count", Some("42"))
+}
+
+pub fn float_default_stringifies_test() {
+  glint.float_flag("ratio")
+  |> glint.flag_default(3.14)
+  |> assert_documented_default("ratio", Some("3.14"))
+}
+
+pub fn string_default_stringifies_test() {
+  glint.string_flag("greeting")
+  |> glint.flag_default("hello")
+  |> assert_documented_default("greeting", Some("hello"))
+}
+
+pub fn bool_true_default_stringifies_test() {
+  glint.bool_flag("enabled")
+  |> glint.flag_default(True)
+  |> assert_documented_default("enabled", Some("true"))
+}
+
+pub fn bool_false_default_stringifies_test() {
+  glint.bool_flag("disabled")
+  |> glint.flag_default(False)
+  |> assert_documented_default("disabled", Some("false"))
+}
+
+pub fn ints_default_stringifies_as_csv_test() {
+  glint.ints_flag("counts")
+  |> glint.flag_default([1, 2, 3])
+  |> assert_documented_default("counts", Some("1,2,3"))
+}
+
+pub fn floats_default_stringifies_as_csv_test() {
+  glint.floats_flag("ratios")
+  |> glint.flag_default([1.0, 2.5])
+  |> assert_documented_default("ratios", Some("1.0,2.5"))
+}
+
+pub fn strings_default_stringifies_as_csv_test() {
+  glint.strings_flag("names")
+  |> glint.flag_default(["a", "b", "c"])
+  |> assert_documented_default("names", Some("a,b,c"))
+}
+
+pub fn flag_without_default_documents_none_test() {
+  glint.int_flag("count")
+  |> assert_documented_default("count", None)
+}
+
+pub fn empty_ints_default_stringifies_as_empty_string_test() {
+  glint.ints_flag("counts")
+  |> glint.flag_default([])
+  |> assert_documented_default("counts", Some(""))
+}

--- a/test/glint/show_flag_defaults_test.gleam
+++ b/test/glint/show_flag_defaults_test.gleam
@@ -1,0 +1,36 @@
+import gleam/string
+import gleeunit/should
+import glint.{Help}
+
+fn cli(show_defaults: Bool) -> glint.Glint(Nil) {
+  let count =
+    glint.int_flag("count")
+    |> glint.flag_default(3)
+    |> glint.flag_help("How many times")
+
+  glint.new()
+  |> glint.show_flag_defaults(show_defaults)
+  |> glint.add(at: [], do: {
+    use _count <- glint.flag(count)
+    glint.command(fn(_, _, _) { Nil })
+  })
+}
+
+fn help_text(g: glint.Glint(Nil)) -> String {
+  let assert Ok(Help(help)) = glint.execute(g, ["--help"])
+  help
+}
+
+pub fn enabled_renders_default_test() {
+  cli(True)
+  |> help_text
+  |> string.contains("(default: 3)")
+  |> should.be_true
+}
+
+pub fn disabled_omits_default_test() {
+  cli(False)
+  |> help_text
+  |> string.contains("(default:")
+  |> should.be_false
+}


### PR DESCRIPTION
Add the recursive Tree type to `glint/help` and the `glint.document/1` accessor, returning a structured view of the entire command graph (commands, flags, defaults, args) for documentation generators.